### PR TITLE
fix KeyError: 'code'

### DIFF
--- a/dspW245.py
+++ b/dspW245.py
@@ -244,7 +244,7 @@ class SmartPlug:
         data = self.bytes(data)
         r = self.send(data, log)
         r = json.loads(r)
-        if r['code'] != 0:
+        if 'code' in r and r['code'] != 0:
             print("Error ({}): {}".format(r['code'], r['message']))
             exit()
         return r


### PR DESCRIPTION
some of the messages that are loaded from json.loads are not having 'code' key and thus the script is crashing.
example: {'command': 'event', 'sequence_id': 1671142336, 'timestamp': 1671142336, 'push_event': 0, 'event': {'type': 61, 'name': 'Setting Change', 'timestamp': 1671142336716349, 'device_id': '58D56E46044E', 'mydlink_no': '38663607', 'metadata': {'value': 1, 'uid': 0, 'type': 16, 'idx': 1}}}